### PR TITLE
fix: Make the path to the welcome image relative

### DIFF
--- a/.github/config.yml
+++ b/.github/config.yml
@@ -17,7 +17,7 @@ newPRWelcomeComment: >
 firstPRMergeComment: >
   Thanks for your contribution to the Layer5 community! :tada:
    
-  ![Congrats!](../.github/welcome/Layer5-celebration.png)
+  ![Congrats!](welcome/Layer5-celebration.png)
 
 
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
**Description**
Make the path to the welcome image relative

This PR fixes #6 

**[Signed commits](CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.